### PR TITLE
DWARF addresses are relative to the start of the code section

### DIFF
--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -48,6 +48,8 @@ impl Debug {
 
 #[derive(Clone, Debug, Default)]
 pub struct DebugMap {
+    /// Offset of code section relative to the Wasm file start.
+    pub code_offset: u32,
     /// Each tuple is `(start, len, loc)`. The `start` offset is
     /// relative to the code section.
     pub tuples: Vec<(u32, u32, SourceLoc)>,
@@ -57,6 +59,7 @@ impl DebugMap {
     pub(crate) fn from_dwarf<R: gimli::Reader>(
         dwarf: gimli::Dwarf<R>,
         debug: &mut Debug,
+        code_offset: u32,
     ) -> anyhow::Result<DebugMap> {
         let ctx = addr2line::Context::from_dwarf(dwarf)?;
         let mut tuples = vec![];
@@ -79,6 +82,9 @@ impl DebugMap {
             retain
         });
 
-        Ok(DebugMap { tuples })
+        Ok(DebugMap {
+            code_offset,
+            tuples,
+        })
     }
 }


### PR DESCRIPTION
This partially reverts the previous commit.

Also fix the logic in `DebugLocReader::get_loc`.

---
My understanding is that there is only one Code section for WASM, and if I put a print in `Payload::CodeSectionStart` it only displays once.

I'm using this patch to display the address:
```diff
diff --git a/src/ir/debug.rs b/src/ir/debug.rs
index b19b484..0cd4329 100644
--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -22,6 +22,7 @@ pub struct SourceLocData {
     pub file: SourceFile,
     pub line: u32,
     pub col: u32,
+    pub address: u32,
 }
 
 impl Debug {
@@ -34,8 +35,8 @@ impl Debug {
         id
     }
 
-    pub fn intern_loc(&mut self, file: SourceFile, line: u32, col: u32) -> SourceLoc {
-        let data = SourceLocData { file, line, col };
+    pub fn intern_loc(&mut self, file: SourceFile, line: u32, col: u32, address: u32) -> SourceLoc {
+        let data = SourceLocData { file, line, col, address };
         match self.source_loc_dedup.entry(data) {
             HashEntry::Vacant(v) => {
                 let id = self.source_locs.push(data);
@@ -67,7 +68,7 @@ impl DebugMap {
         let mut locs = ctx.find_location_range(0, u64::MAX).unwrap();
         while let Some((start, len, loc)) = locs.next() {
             let file = debug.intern_file(loc.file.unwrap_or(""));
-            let loc = debug.intern_loc(file, loc.line.unwrap_or(0), loc.column.unwrap_or(0));
+            let loc = debug.intern_loc(file, loc.line.unwrap_or(0), loc.column.unwrap_or(0), start as u32);
             log::trace!("tuple: loc {} start {:x} len {:x}", loc, start, len);
             tuples.push((start as u32, len as u32, loc));
         }
diff --git a/src/ir/display.rs b/src/ir/display.rs
index d0cb7ec..bbf14bd 100644
--- a/src/ir/display.rs
+++ b/src/ir/display.rs
@@ -130,7 +130,7 @@ impl<'a> Display for FunctionBodyDisplay<'a> {
                             let loc = self.0.source_locs[inst];
                             let data = &module.debug.source_locs[loc];
                             let filename = &module.debug.source_files[data.file];
-                            format!("@{} {}:{}:{}", loc, filename, data.line, data.col)
+                            format!("@{} {}:{}:{} {:x}", loc, filename, data.line, data.col, data.address)
                         } else {
                             "".to_owned()
                         };
@@ -267,8 +267,8 @@ impl<'a> Display for ModuleDisplay<'a> {
         for (loc, loc_data) in self.0.debug.source_locs.entries() {
             writeln!(
                 f,
-                "  {} = {} line {} column {}",
-                loc, loc_data.file, loc_data.line, loc_data.col
+                "  {} = {} line {} column {} address {:x}",
+                loc, loc_data.file, loc_data.line, loc_data.col, loc_data.address
             )?;
         }
         for (file, file_name) in self.0.debug.source_files.entries() {
```

From looking at the DWARF, I know that `func879` starts at address 0x0005c7c2

Prior to this PR, `func879` shows locs such as the following, with the wrong address:
```
        v6 = global_get<global0>  # i32 @loc931733 /Users/cfallin/work/gecko-dev/obj-release/dist/include/js/Class.h:749:25 62f2d
        v7 = i32const<240>  # i32 @loc931734 /Users/cfallin/work/gecko-dev/obj-release/dist/include/js/Class.h:0:25 62f34
        v8 = i32sub v6, v7 # i32 @loc931735 /Users/cfallin/work/gecko-dev/js/src/vm/ObjectOperations-inl.h:114:21 62f35
        v9 = global_set<global0> v8 #  @loc931737 /Users/cfallin/work/gecko-dev/js/src/vm/ObjectOperations-inl.h:115:12 62f40
```

With this PR, I get:
```
        v6 = global_get<global0>  # i32 @loc927607 /Users/cfallin/work/gecko-dev/js/src/vm/Interpreter.cpp:2062:0 5c7c2
        v7 = i32const<240>  # i32 @loc927607 /Users/cfallin/work/gecko-dev/js/src/vm/Interpreter.cpp:2062:0 5c7c2
        v8 = i32sub v6, v7 # i32 @loc927607 /Users/cfallin/work/gecko-dev/js/src/vm/Interpreter.cpp:2062:0 5c7c2
        v9 = global_set<global0> v8 #  @loc927607 /Users/cfallin/work/gecko-dev/js/src/vm/Interpreter.cpp:2062:0 5c7c2
```
