### PR TITLE
Prevent const prop of const op

### DIFF
--- a/src/passes/basic_opt.rs
+++ b/src/passes/basic_opt.rs
@@ -204,7 +204,14 @@ impl<'a> BasicOptPass<'a> {
                             .iter()
                             .map(|&arg| value_is_const(arg, body))
                             .collect::<Vec<_>>();
-                        let const_val = const_eval(op, &arg_values[..], None);
+                        let const_val = match op {
+                            Operator::I32Const { .. }
+                            | Operator::I64Const { .. }
+                            | Operator::F32Const { .. }
+                            | Operator::F64Const { .. }
+                            | Operator::V128Const { .. } => None,
+                            _ => const_eval(op, &arg_values[..], None),
+                        };
                         match const_val {
                             Some(ConstVal::I32(val)) => {
                                 value = ValueDef::Operator(


### PR DESCRIPTION
The changes introduced in https://github.com/cfallin/waffle/commit/bde62867daa022165fb289a8b510b5102f1118e8 lead to an endless loop when constant propagation is enabled. This is because an already constant value will be “transformed” into itself and the `changed` flag set to `true`. This PR fixes this by setting `const_val` to `None` if the existing `op` already is a constant. It works but may not be the prettiest way to prevent a const to const propagation. There are other places where that check can be performed, for example on the `value` itself rather than the `op`, maybe using the `value_is_const` function. If you know a better place to do this just tell me and I’ll update the PR. ^-^
