### PR TITLE
Support irreducible control flow by converting it to reducible control flow.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2"
 addr2line = "0.21"
 
 # For fuzzing only. Versions must match those in fuzz/Cargo.toml.
-libfuzzer-sys = { version = "0.4", optional = true }
+libfuzzer-sys = { version = "0.4.7", optional = true }
 wasm-smith = { version = "0.202", optional = true }
 
 [features]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,8 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.4"
+libfuzzer-sys = { version = "0.4.7" }
+arbitrary = { version = "1.3.2", features = ["derive"] }
 wasm-smith = "0.202.0"
 env_logger = "0.9"
 log = "0.4"
@@ -52,5 +53,11 @@ doc = false
 [[bin]]
 name = "opt_diff"
 path = "fuzz_targets/opt_diff.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "irreducible"
+path = "fuzz_targets/irreducible.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/irreducible.rs
+++ b/fuzz/fuzz_targets/irreducible.rs
@@ -1,0 +1,95 @@
+//! Fuzzing irreducible control flow handling.
+//!
+//! 1. Generate a testcase with an arbitrary CFG.
+//! 2. Compile it.
+//!
+//! (That's it.) Showing equivalence of execution is a harder problem
+//! and is left as a future exercise.
+
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use waffle::{
+    entity::PerEntity, Block, BlockTarget, FuncDecl, FunctionBody, Module, SignatureData,
+    Terminator, Type,
+};
+
+#[derive(Clone, Debug, Arbitrary)]
+struct CFG {
+    num_blocks: u8,
+    edges: Vec<(u8, u8)>,
+}
+
+impl CFG {
+    fn to_module(&self) -> Module {
+        let mut module = Module::empty();
+        let sig = module.signatures.push(SignatureData {
+            params: vec![Type::I32],
+            returns: vec![],
+        });
+
+        let num_blocks = u32::from(std::cmp::max(1, self.num_blocks));
+
+        let mut body = FunctionBody::new(&module, sig);
+
+        // Entry block0 already present; add the rest.
+        for _ in 1..num_blocks {
+            let block = body.add_block();
+            body.add_blockparam(block, Type::I32);
+        }
+
+        let mut edges_by_origin: PerEntity<Block, Vec<Block>> = PerEntity::default();
+        for &(from, to) in &self.edges {
+            let from = Block::from(u32::from(from) % num_blocks);
+            let to = Block::from(u32::from(to) % num_blocks);
+            edges_by_origin[from].push(to);
+        }
+
+        for (block, def) in body.blocks.entries_mut() {
+            let param = def.params[0].1;
+            let dests = &edges_by_origin[block];
+            let mut targets = dests
+                .iter()
+                .map(|&dest| BlockTarget {
+                    block: dest,
+                    args: vec![param],
+                })
+                .collect::<Vec<_>>();
+            let terminator = match dests.len() {
+                0 => Terminator::Return {
+                    values: vec![param],
+                },
+                1 => Terminator::Br {
+                    target: targets[0].clone(),
+                },
+                2 => Terminator::CondBr {
+                    cond: param,
+                    if_true: targets[0].clone(),
+                    if_false: targets[1].clone(),
+                },
+                _ => {
+                    let default = targets.pop().unwrap();
+                    Terminator::Select {
+                        value: param,
+                        targets,
+                        default,
+                    }
+                }
+            };
+            def.terminator = terminator;
+        }
+
+        body.recompute_edges();
+        body.validate().unwrap();
+        module
+            .funcs
+            .push(FuncDecl::Body(sig, "func0".to_string(), body));
+        module
+    }
+}
+
+fuzz_target!(|cfg: CFG| {
+    let _ = env_logger::try_init();
+    let module = cfg.to_module();
+    let _ = module.to_wasm_bytes().unwrap();
+});

--- a/src/backend/reducify.rs
+++ b/src/backend/reducify.rs
@@ -4,6 +4,27 @@
 //! branching back to the main loop as soon as control passes through
 //! the loop header again.
 //!
+//! # Limitations
+//!
+//! ***WARNING*** EXPONENTIAL BLOWUP POTENTIAL ***WARNING***
+//!
+//! This pass is designed on the assumption that irreducible control
+//! flow is rare, and needs to be handled somehow but it's OK to,
+//! e.g., duplicate most of a loop body to do so. The tradeoff that
+//! we're aiming for is that we want zero runtime overhead -- we do
+//! not want a performance cliff if someone accidentally introduces an
+//! irreducible edge -- and we're hoping that this remains rare. If
+//! you feed this pass a state machine, or a fully-connected clique,
+//! for example, or even a deep nest of loops, one can get much worse
+//! than 2x code-size increase. You have been warned!
+//!
+//! In the future we may consider a hybrid approach where we start
+//! with this algorithm, keep track of block-count increase, and abort
+//! and move to a Relooper-style (dynamic label variable-based)
+//! approach with no code duplication if a threshold is reached.
+//!
+//! ***WARNING*** EXPONENTIAL BLOWUP POTENTIAL ***WARNING***
+//!
 //! # Finding Loop Headers
 //!
 //! The basic idea is that we compute RPO and treat all backedges in

--- a/src/backend/reducify.rs
+++ b/src/backend/reducify.rs
@@ -149,7 +149,7 @@
 //! merge-point between different copies of the same subgraph.
 
 use crate::entity::EntityRef;
-use crate::{cfg::CFGInfo, entity::PerEntity, Block, FunctionBody, cfg::RPOIndex, Value, ValueDef};
+use crate::{cfg::CFGInfo, cfg::RPOIndex, entity::PerEntity, Block, FunctionBody, Value, ValueDef};
 use fxhash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use std::borrow::Cow;

--- a/src/backend/reducify.rs
+++ b/src/backend/reducify.rs
@@ -1,0 +1,549 @@
+//! Reducification: turning a potentially irreducible CFG into a
+//! reducible CFG. We perform context-sensitive code duplication to
+//! "peel off" the parts of loops that are reached by side-entrances,
+//! branching back to the main loop as soon as control passes through
+//! the loop header again.
+//!
+//! # Finding Loop Headers
+//!
+//! The basic idea is that we compute RPO and treat all backedges in
+//! RPO (i.e., edges from rpo-index i to rpo-index j, where j <= i) as
+//! loop backedges, with all blocks "under the edge" (with RPO indices
+//! i..=j) in the loop. We then "properly nest" loops, so if we have,
+//! e.g.:
+//!
+//! ```plain
+//!     block0
+//!     block1  |
+//!     block2  | loop     |
+//!     block3  |          |
+//!     block4             | loop
+//! ```
+//!
+//! we "fix the nesting" by pushing down the lower extent of the first
+//! loop to block4. We do so in a single post-pass fixup scan that
+//! keeps a stack, pushes when meeting a loop header, pops while the
+//! innermost is no longer in the initial header-set, then ensures
+//! that all header-blockson the stack are inserted into every
+//! header-set it passes over.
+//!
+//! The effect of this is to compute a loop nest *as if* irreducible
+//! edges (side loop entrances) did not exist. We'll fix them up later
+//! with the code duplication.
+//!
+//! # Finding Irreducible Loop Headers
+//!
+//! After computing header-sets, find edges from B1 to B2 such that
+//! headers(B2) - headers(B1) - {B2} is non-empty -- that is, we add a
+//! header block (enter a new loop) going from B1 to B2, and that new
+//! header block is not B2 itself. This is a "side-entrance" into a
+//! loop, and is irreducible.
+//!
+//! # Duplicating Code
+//!
+//! We create blocks under contexts defined by "skipped
+//! headers", where the context is computed at at an edge
+//! (From, To) as (where `U` is set union, `-` is set
+//! subtraction, `&` is set intersection, `!S` is the set
+//! complement):
+//!
+//! ```plain
+//!     Gen = (headers(To) - headers(From)) - {To}
+//!         = headers(To) & !headers(From) & !{To}
+//!     Kill = (headers(From) - headers(To)) U {To}
+//!          = (headers(From) & !headers(To)) U {To}
+//!
+//! let ToContext = (FromContext - Kill) U Gen
+//!               = (FromContext & !Kill) U Gen
+//!               = (FromContext & !((headers(From) & !headers(To)) U {To})) U
+//!                 (headers(To) & !headers(From) & !{To})
+//!               = (FromContext & !((headers(From) U {To}) & (!headers(To) U {To}))) U
+//!                 (headers(To) & !headers(From) & !{To})
+//!               = (FromContext & (!(headers(From) U {To}) U !(!headers(To) U {To}))) U
+//!                 (headers(To) & !headers(From) & !{To})
+//!               = (FromContext & ((!headers(From) & !{To}) U (headers(To) & !{To}))) U
+//!                 (headers(To) & !headers(From) & !{To})
+//!               = (FromContext & !headers(From) & !{To}) U
+//!                 (FromContext & headers(To) & !{To}) U
+//!                 (headers(To) & !headers(From) & !{To})
+//! ```
+//!
+//! invariant: for every B, we only ever have a context C where C c headers(B)
+//!
+//! then the first term goes away (FromContext & !headers(From)
+//! = 0) and we can simplify to:
+//!
+//! ```plain
+//! let ToContext = headers(To) & !{To} & (FromContext U !headers(From))
+//! ```
+//!
+//! in other words: when entering a loop except through its
+//! header, add to context; stay in that context inside the
+//! loop; leave the context when we leave the loop.
+//!
+//! Note that in the case with no irreducible edges, this
+//! becomes the special case where every context is {} and no
+//! blocks are actually duplicated (but we returned early above
+//! to avoid this no-op transform).
+//!
+//! Patching up use-def links is somewhat tricky. Consider the
+//! CFG:
+//!
+//! ```plain
+//!         1
+//!        / \
+//!       /   \
+//!      2 --> 3
+//!      2 <-- 3
+//!           /
+//!          4
+//! ```
+//!
+//! Which is irreducible (it contains the canonical irreducible
+//! graph 1->2, 2->3, 3->2) and has an exit-path with block 4
+//! that is dominated by block 3. Block 4 can thus use values
+//! defined in block 3, but if we perform elaboration as:
+//!
+//! ```plain
+//!     1
+//!   /  \__
+//!  2<.<--3'
+//!  v ^   |
+//!  3-/  _|
+//!   \ /
+//!    4
+//! ```
+//!
+//! that is, we have two copies of the block 3,and each has an
+//! exit to the one copy of 4.
+//!
+//! Any values defined in 3 and used in 4 in the original CFG
+//! will need to pass through blockparams to merge the two
+//! versions in the elaborated CFG.
+//!
+//! To fix this problem, we perform a max-SSA cut at all blocks
+//! that have an in-edge from a block with a larger header-set
+//! (i.e., a loop exit edge) if the exited loop has a
+//! side-entrance; this is the only way in which we can have a
+//! merge-point between different copies of the same subgraph.
+
+use crate::entity::EntityRef;
+use crate::{cfg::CFGInfo, entity::PerEntity, Block, FunctionBody, cfg::RPOIndex, Value, ValueDef};
+use fxhash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
+use std::borrow::Cow;
+use std::collections::{HashSet, VecDeque};
+
+pub struct Reducifier<'a> {
+    body: &'a FunctionBody,
+    cfg: CFGInfo,
+    blocks: PerEntity<Block, BlockState>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct BlockState {
+    headers: FxHashSet<Block>,
+    is_header: bool,
+}
+
+impl<'a> Reducifier<'a> {
+    pub fn new(body: &'a FunctionBody) -> Reducifier<'a> {
+        let cfg = CFGInfo::new(body);
+        Reducifier {
+            body,
+            cfg,
+            blocks: PerEntity::default(),
+        }
+    }
+
+    pub fn run(&mut self) -> Cow<'a, FunctionBody> {
+        // First, compute all of the loop header-sets.
+        // - Start by computing RPO.
+        // - Find backedges (edges (a, b) where rpo(b) <= rpo(a)).
+        // - For each backedge, mark extent of rpo-indices "under"
+        //   edge as within header.
+        // - Do one forward pass to properly nest regions, keeping
+        //   stack of headers when we entered their regions and
+        //   enforcing LIFO by extending appropriately.
+        let cfg = CFGInfo::new(&self.body);
+
+        for (rpo, &block) in cfg.rpo.entries() {
+            for &succ in &self.body.blocks[block].succs {
+                let succ_rpo = cfg.rpo_pos[succ].unwrap();
+                if succ_rpo.index() <= rpo.index() {
+                    for i in succ_rpo.index()..=rpo.index() {
+                        let b = cfg.rpo[RPOIndex::new(i)];
+                        self.blocks[b].headers.insert(succ);
+                        self.blocks[b].is_header = true;
+                    }
+                }
+            }
+        }
+
+        let mut header_stack = vec![];
+        for &block in cfg.rpo.values() {
+            while let Some(innermost) = header_stack.last() {
+                if !self.blocks[block].headers.contains(innermost) {
+                    header_stack.pop();
+                } else {
+                    break;
+                }
+            }
+            if self.blocks[block].is_header {
+                header_stack.push(block);
+            }
+
+            for &header in &header_stack {
+                self.blocks[block].headers.insert(header);
+            }
+        }
+
+        // Now, check whether any irreducible edges exist: edges from
+        // B1 to B2 where headers(B2) - headers(B1) - {B2} is not
+        // empty (i.e., the edge jumps into a new loop -- adds a new
+        // header -- without going through that header block).
+        let mut irreducible_headers: FxHashSet<Block> = FxHashSet::default();
+        for (block, data) in self.body.blocks.entries() {
+            let headers = &self.blocks[block].headers;
+            for &succ in &data.succs {
+                log::trace!("examining edge {} -> {}", block, succ);
+                for &succ_header in &self.blocks[succ].headers {
+                    log::trace!("  successor {} has header {}", succ, succ_header);
+                    if succ_header != succ && !headers.contains(&succ_header) {
+                        log::trace!("    -> irreducible edge");
+                        irreducible_headers.insert(succ_header);
+                    }
+                }
+            }
+        }
+
+        if irreducible_headers.is_empty() {
+            return Cow::Borrowed(self.body);
+        }
+
+        if log::log_enabled!(log::Level::Trace) {
+            for block in self.body.blocks.iter() {
+                let mut headers = self.blocks[block]
+                    .headers
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                headers.sort();
+                log::trace!("* {}: header set {:?}", block, headers);
+            }
+        }
+
+        // Now, in the irreducible case, "elaborate" the CFG.
+
+        // First do limited conversion to max-SSA to fix up references
+        // across contexts.
+        let mut cut_blocks = HashSet::default();
+        for (block, data) in self.body.blocks.entries() {
+            for &succ in &data.succs {
+                // Loop exits
+                for header in &self.blocks[block].headers {
+                    if !self.blocks[succ].headers.contains(header)
+                        && irreducible_headers.contains(header)
+                    {
+                        log::trace!("cut-block at loop exit: {}", succ);
+                        cut_blocks.insert(succ);
+                    }
+                }
+                // Loop side entries
+                for header in &self.blocks[succ].headers {
+                    if !self.blocks[block].headers.contains(header) && *header != succ {
+                        log::trace!("cut-block at loop side entry: {}", succ);
+                        cut_blocks.insert(succ);
+                    }
+                }
+            }
+        }
+
+        let mut new_body = self.body.clone();
+        let cfg = CFGInfo::new(&new_body);
+        crate::passes::maxssa::run(&mut new_body, Some(cut_blocks), &cfg);
+        crate::passes::resolve_aliases::run(&mut new_body);
+
+        log::trace!("after max-SSA run:\n{}\n", new_body.display("| ", None));
+
+        // Implicitly, context {} has an identity-map from old block
+        // number to new block number. We use the map only for
+        // non-empty contexts.
+        let mut context_map: FxHashMap<Vec<Block>, usize> = FxHashMap::default();
+        let mut contexts: Vec<Vec<Block>> = vec![vec![]];
+        context_map.insert(vec![], 0);
+        let mut block_map: FxHashMap<(usize, Block), Block> = FxHashMap::default();
+        let mut value_map: FxHashMap<(usize, Value), Value> = FxHashMap::default();
+
+        // List of (ctx, new block) tuples for duplicated code.
+        let mut cloned_blocks: Vec<(usize, Block)> = vec![];
+        // Map from block in new body to (ctx, orig block) target, to
+        // allow updating terminators.
+        let mut terminators: FxHashMap<Block, Vec<(usize, Block)>> = FxHashMap::default();
+
+        let mut queue: VecDeque<(usize, Block)> = VecDeque::new();
+        let mut visited: FxHashSet<(usize, Block)> = FxHashSet::default();
+        queue.push_back((0, new_body.entry));
+        visited.insert((0, new_body.entry));
+        while let Some((ctx, block)) = queue.pop_front() {
+            log::trace!(
+                "elaborate: block {} in context {} ({:?})",
+                block,
+                ctx,
+                contexts[ctx]
+            );
+
+            // If this is a non-default context, replicate the block.
+            let new_block = if ctx != 0 {
+                log::trace!("cloning block {} in new context", block);
+                let new_block = new_body.add_block();
+                new_body.blocks[new_block].desc = format!("Cloned {}", block);
+                let params = new_body.blocks[block].params.clone();
+                for (ty, val) in params {
+                    let blockparam = new_body.add_blockparam(new_block, ty);
+                    value_map.insert((ctx, val), blockparam);
+                }
+
+                block_map.insert((ctx, block), new_block);
+                cloned_blocks.push((ctx, new_block));
+
+                // Copy over all value definitions, but don't rewrite
+                // args yet -- we'll do a separate pass for that.
+                let insts = new_body.blocks[block].insts.clone();
+                for value in insts {
+                    let def = new_body.values[value].clone();
+                    let new_value = new_body.values.push(def);
+                    value_map.insert((ctx, value), new_value);
+                    new_body.blocks[new_block].insts.push(new_value);
+                }
+
+                // Copy over the terminator but don't update yet --
+                // we'll do that later too.
+                new_body.blocks[new_block].terminator = new_body.blocks[block].terminator.clone();
+
+                new_block
+            } else {
+                block
+            };
+
+            // For every terminator, determine the target context:
+            //
+            // let ToContext = headers(To) & !{To} & (FromContext U !headers(From))
+            let term = terminators.entry(new_block).or_insert_with(|| vec![]);
+            let succs = new_body.blocks[block].succs.clone();
+            for succ in succs {
+                let mut ctx_blocks = self.blocks[succ]
+                    .headers
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                ctx_blocks.sort();
+                ctx_blocks.retain(|&header_block| {
+                    header_block != succ
+                        && (contexts[ctx].contains(&header_block)
+                            || !self.blocks[block].headers.contains(&header_block))
+                });
+                let to_ctx = *context_map.entry(ctx_blocks.clone()).or_insert_with(|| {
+                    let id = contexts.len();
+                    contexts.push(ctx_blocks);
+                    id
+                });
+                log::trace!(
+                    "elaborate: edge {} -> {} from ctx {:?} goes to ctx {:?}",
+                    block,
+                    succ,
+                    contexts[ctx],
+                    contexts[to_ctx]
+                );
+
+                term.push((to_ctx, succ));
+
+                if visited.insert((to_ctx, succ)) {
+                    log::trace!("enqueue block {} ctx {}", succ, to_ctx);
+                    queue.push_back((to_ctx, succ));
+                }
+            }
+        }
+
+        // Second pass: rewrite args, and set up terminators. Both
+        // happen in a second pass so that we have the block- and
+        // value-map available for all blocks and values, regardless
+        // of cycles or processing order.
+        for (ctx, new_block) in cloned_blocks {
+            for &inst in &new_body.blocks[new_block].insts {
+                match &mut new_body.values[inst] {
+                    ValueDef::Operator(_, args, _) => {
+                        let new_args = new_body.arg_pool[*args]
+                            .iter()
+                            .map(|&val| value_map.get(&(ctx, val)).cloned().unwrap_or(val))
+                            .collect::<SmallVec<[Value; 4]>>();
+                        let new_args = new_body.arg_pool.from_iter(new_args.into_iter());
+                        *args = new_args;
+                    }
+                    ValueDef::PickOutput(val, _, _) | ValueDef::Alias(val) => {
+                        *val = value_map.get(&(ctx, *val)).cloned().unwrap_or(*val);
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            new_body.blocks[new_block]
+                .terminator
+                .update_uses(|u| *u = value_map.get(&(ctx, *u)).cloned().unwrap_or(*u));
+        }
+
+        for (block, block_def) in new_body.blocks.entries_mut() {
+            log::trace!("processing terminators for block {}", block);
+            let terms = match terminators.get(&block) {
+                Some(t) => t,
+                // If no entry in `terminators`, we didn't visit the
+                // block; it must not be reachable.
+                None => continue,
+            };
+            let mut terms = terms.iter();
+            block_def.terminator.update_targets(|target| {
+                let &(to_ctx, to_orig_block) = terms.next().unwrap();
+                target.block = block_map
+                    .get(&(to_ctx, to_orig_block))
+                    .cloned()
+                    .unwrap_or(to_orig_block);
+            });
+        }
+
+        new_body.recompute_edges();
+
+        log::trace!("After duplication:\n{}\n", new_body.display("| ", None));
+
+        new_body.validate().unwrap();
+        new_body.verify_reducible().unwrap();
+
+        Cow::Owned(new_body)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        entity::EntityRef, BlockTarget, FuncDecl, Module, Operator, SignatureData, Terminator,
+        Type, ValueDef,
+    };
+
+    #[test]
+    fn test_irreducible() {
+        let _ = env_logger::try_init();
+
+        let mut module = Module::empty();
+        let sig = module.signatures.push(SignatureData {
+            params: vec![Type::I32, Type::I64, Type::F64],
+            returns: vec![Type::I64],
+        });
+        let mut body = FunctionBody::new(&module, sig);
+
+        let block1 = body.entry;
+        let block2 = body.add_block();
+        let block3 = body.add_block();
+        let block4 = body.add_block();
+
+        let arg0 = body.blocks[block1].params[0].1;
+        let arg1 = body.blocks[block1].params[1].1;
+        let arg2 = body.blocks[block1].params[2].1;
+
+        body.set_terminator(
+            block1,
+            Terminator::CondBr {
+                cond: arg0,
+                if_true: BlockTarget {
+                    block: block2,
+                    args: vec![arg1],
+                },
+                if_false: BlockTarget {
+                    block: block3,
+                    args: vec![arg2],
+                },
+            },
+        );
+
+        let block2_param = body.add_blockparam(block2, Type::I64);
+        let block3_param = body.add_blockparam(block3, Type::F64);
+
+        let args = body.arg_pool.single(block2_param);
+        let f64_ty = body.single_type_list(Type::F64);
+        let block2_param_cast = body.add_value(ValueDef::Operator(
+            Operator::F64ReinterpretI64,
+            args,
+            f64_ty,
+        ));
+        body.blocks[block2].insts.push(block2_param_cast);
+
+        let args = body.arg_pool.single(block3_param);
+        let i64_ty = body.single_type_list(Type::I64);
+        let block3_param_cast = body.add_value(ValueDef::Operator(
+            Operator::I64ReinterpretF64,
+            args,
+            i64_ty,
+        ));
+        body.blocks[block3].insts.push(block3_param_cast);
+
+        body.set_terminator(
+            block2,
+            Terminator::Br {
+                target: BlockTarget {
+                    block: block3,
+                    args: vec![block2_param_cast],
+                },
+            },
+        );
+        body.set_terminator(
+            block3,
+            Terminator::CondBr {
+                cond: arg0,
+                if_true: BlockTarget {
+                    block: block2,
+                    args: vec![block3_param_cast],
+                },
+                if_false: BlockTarget {
+                    block: block4,
+                    args: vec![],
+                },
+            },
+        );
+
+        body.set_terminator(
+            block4,
+            Terminator::Return {
+                values: vec![block3_param_cast],
+            },
+        );
+
+        log::debug!("Body:\n{}", body.display("| ", Some(&module)));
+
+        body.validate().unwrap();
+
+        let mut reducifier = Reducifier::new(&body);
+        let new_body = reducifier.run();
+
+        new_body.validate().unwrap();
+
+        log::debug!("Reducified body:\n{}", body.display("| ", Some(&module)));
+
+        let cfg = CFGInfo::new(&new_body);
+        for (block, def) in new_body.blocks.entries() {
+            for &succ in &def.succs {
+                // For any edge to a block earlier in RPO, that block
+                // must dominate us.
+                if cfg.rpo_pos[succ].unwrap().index() <= cfg.rpo_pos[block].unwrap().index() {
+                    assert!(cfg.dominates(succ, block));
+                }
+            }
+        }
+
+        // Now ensure we can generate a Wasm module (with reducible
+        // control flow).
+        module
+            .funcs
+            .push(FuncDecl::Body(sig, "func0".to_string(), body));
+        let wasm = module.to_wasm_bytes().unwrap();
+        log::debug!("wasm bytes: {:?}", wasm);
+    }
+}

--- a/src/backend/stackify.rs
+++ b/src/backend/stackify.rs
@@ -23,7 +23,7 @@ pub enum WasmBlock<'a> {
         body: Vec<WasmBlock<'a>>,
         out: Block,
     },
-    /// A Wasm loop that has the given contents and whos label jumps
+    /// A Wasm loop that has the given contents and whose label jumps
     /// to the given CFG block header.
     Loop {
         body: Vec<WasmBlock<'a>>,

--- a/src/ir/module.rs
+++ b/src/ir/module.rs
@@ -150,6 +150,23 @@ impl<'a> Module<'a> {
         }
     }
 
+    pub fn empty() -> Module<'static> {
+        Module {
+            orig_bytes: &[],
+            funcs: EntityVec::default(),
+            signatures: EntityVec::default(),
+            globals: EntityVec::default(),
+            tables: EntityVec::default(),
+            imports: vec![],
+            exports: vec![],
+            memories: EntityVec::default(),
+            start_func: None,
+            debug: Debug::default(),
+            debug_map: DebugMap::default(),
+            custom_sections: BTreeMap::default(),
+        }
+    }
+
     pub fn without_orig_bytes(self) -> Module<'static> {
         Module {
             orig_bytes: &[],


### PR DESCRIPTION
Wasm supports expressing only reducible control flow via its structured control flow mechanisms (forward-branches out of blocks and backward-branches to loop headers, in addition to structured if/else diamonds).

waffle accepts an arbitrary CFG as its IR, and this CFG is perfectly capable of expressing irreducible CFGs. For example, the canonical irreducible CFG

```plain
      1
    /   \
   /     \
  2 ----> 3
    <---
```

(that is, the graph with edges 1->2, 1->3, 2->3, 3->2) cannot be expressed in Wasm as direct control flow. Instead, a compiler that targets Wasm needs to either use indirection -- `i32` values as target tags that are fed into switches (`br_table`s), usually -- or code duplication. For the former case, we could build a loop body out of blocks 2 and 3 that accepts a header parameter that selects between 2 or 3; this "lowered loop" iterates twice as many times as the original loop. For the latter case, we could duplicate either block 2 or 3 and then "fall into" the main loop, for example by doing:

```plain
         1
    _  /   \
   | \/     \
   | 2 <---- 3'
   | |
   | |
   | 3
   \_/

```

The advantage of the label-variable approach is that it does not duplicate code; it adds a small constant overhead to code size per irreducible loop instead. The disadvantage is that it adds runtime cost, which is a potentially significant performance cliff if an unexpected irreducible side-edge is added for some reason. In addition, it has some significant implementation complexity:

- All entrances to a loop are indirected through the one header block. When we support blockparams and perform the reducibility transform on the CFG, we need to find the *union* of all blockparam signatures of all side-entrances and rewrite block targets to use "default" zero-values for the gaps (unused parameters for the dynamically-selected target). This is very awkward, and potentially impossible when we have non-nullable values (e.g. GC refs) in the future.

- When a side-entrance to a *nested* loop occurs, we need to indirect through multiple header blocks. This adds complexity to the transform too because we need to "fixpoint" the transform somehow: the branch targets of the header block's `br_table` also need to be transformed.

In this PR, instead, I opted for the code-duplication approach. It has at most 2x code-size overhead (duplicate all but the header block in a loop, if we have a side-entrance one block later in the loop body), but has zero runtime overhead. In addition, it avoids the complexities above.

This PR adds the Reducifier, a transform whose approach is described in a module-level comment in `backend/reducify.rs`. In brief, the idea is to:

1. Compute an approximate loop-nest over the CFG, computing "header sets" for every block that describe the loops the blocks belong to. We do this by first computing a reverse postorder, then finding RPO backedges (edges from rpo-index `i` to rpo-index `j` such that `j <= i`), adding the header (target with lower RPO index) to all header-sets "under" the edge (rpo-indices from `i` to `j` inclusive), then fixing up loop nesting in one final pass over the header-sets in RPO order with a stack that tracks the nest, "pushing out" the extent of outer loops to cover inner loops that start within their extent.

   In the above canonical irreducible CFG, blocks 2 and 3 will have header-sets of either `{2}` or `{3}`, depending on which of the two valid reverse postorders the initial RPO computation chose (which depends on which out-edges are visited first).

3. Find irreducible edges given these header sets: these are edges from `B1` to `B2` such that header `H` is in `headers(B2)` but not `headers(B1)`, and `H != B2`. (Intuitively, a "side-entrance".) If no such edges exist, the CFG is reducible; early-out without modifications.

4. Perform a context-sensitive code-duplication pass. We define a *context set* per block that is like the header set, but the dual: it denotes "side-entered loops". (Formally, moving across an edge `(From, To)`, we compute `ToContext = headers(To) & !{To} & (FromContext U !headers(From))`: this adds to the context when we side-enter a loop, and removes from the context when we jump back to the loop header or leave the loop.)

   As part of this, we perform a limited "max-SSA" pass on a set of cut-blocks computed as side-entrances and exits (that is, exactly blocks where we change context), so that when we duplicate code, we don't have to reason about fixing up SSA across stapled-together duplicated code fragments.

This results in a reducible CFG, which we can then compile with the rest of waffle's backend.